### PR TITLE
Clear if missing pid

### DIFF
--- a/tasks/run.js
+++ b/tasks/run.js
@@ -177,6 +177,7 @@ function makeTask(grunt) {
 
   grunt.task.registerMultiTask('stop', 'stop a process started with "run" ' +
     '(only works for tasks that use wait:false)', function () {
+      
     var pid = this.data._pid;
     var name = this.target;
     var proc = _.find(runningProcs, { pid: pid });


### PR DESCRIPTION
Hey @spenceralger,

Thanks for the handy tasks.   I've been running into issues with the process I'm launching with this dying on it's own (i.e. unhandled exception thrown), and not being able to re-launch it.   Tracked this down to the stop code, which wouldn't clear the _pid when the process was closed, thus preventing it from being restarted. 

sprinkled in a few clearPid() calls, and everything is happy again. 

lmk if you have questions,
steve
