### PR TITLE
Listen to stderr for readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Default value: 1000
 
 If we are **not** waiting for the process to complete, then how do we know the process is ready?
 
-A RegExp will test the lines from stdout and complete the task once the test succeeds, a Number will just set a timeout, and anything else will complete the task on nextTick
+A RegExp will test the lines from stdout and stderr and complete the task once the test succeeds, a Number will just set a timeout, and anything else will complete the task on nextTick
 
 #### options.failOnError
 Type: `Boolean`

--- a/tasks/run.js
+++ b/tasks/run.js
@@ -191,11 +191,13 @@ function makeTask(grunt) {
         outputBuffer = '';
         proc.removeListener('close', onCloseBeforeReady);
         proc.stdout.removeListener('data', checkChunkForReady);
+        proc.stderr.removeListener('data', checkChunkForReady);
         done();
       }
 
       proc.on('close', onCloseBeforeReady);
       proc.stdout.on('data', checkChunkForReady);
+      proc.stderr.on('data', checkChunkForReady);
     }
 
     function waitForTimeout() {


### PR DESCRIPTION
It may be useful check readiness from both stdout and stderr in the case that the process being ran is outputting information to stderr.