### PR TITLE
Fix typo in run.js options

### DIFF
--- a/src/tasks/run.js
+++ b/src/tasks/run.js
@@ -69,7 +69,7 @@ function makeTask(grunt) {
     const opts = this.options({
       wait: true,
       failOnError: false,
-      quite: false,
+      quiet: false,
       ready: 1000,
       cwd: process.cwd(),
       passArgs: [],


### PR DESCRIPTION
The run.js options defines a "quite" option when it really means "quiet".  This works because later tests that look for quiet to be false succeed if the option simply isn't present, but it's just a little ugly :-)